### PR TITLE
fix: typos

### DIFF
--- a/auto-logout.md
+++ b/auto-logout.md
@@ -9,16 +9,16 @@ description: >-
 
 ### Configuring auto logout policy
 
-**Important to understand**: This is a policy that is enforced on the identity server. Not on in the application code!
+**Important to understand**: This is a policy that is enforced on the identity server. Not in the application code!
 
-In OIDC provider it is usually refered to as **Idle Session Lifetime**, this values define for how long an inactive session should be kept in the records of the server.  &#x20;
+In OIDC provider, it is usually referred to as **Idle Session Lifetime**, these values define how long an inactive session should be kept in the records of the server.
 
 Guide on how to configure it:
 
-* [keycloloak](providers-configuration/keycloak.md#security-sensitive-apps-banking-admin-panels-etc)
+* [Keycloak](providers-configuration/keycloak.md#security-sensitive-apps-banking-admin-panels-etc)
 * [Auth0](providers-configuration/auth0.md#optional-configuring-auto-logout)
 
-[If your OIDC provider issue a Refresh Token and if this refresh token is a JWT](#user-content-fn-1)[^1] you don't need to configure anything at the app level. Otherwise you need to explicitely set the `idleSessionLifetimeInSeconds` so it matches how you have configured your server. &#x20;
+[If your OIDC provider issues a Refresh Token and if this refresh token is a JWT](#user-content-fn-1)[^1] you don't need to configure anything at the app level. Otherwise you need to explicitly set the `idleSessionLifetimeInSeconds` so it matches with how you have configured your server.
 
 {% tabs %}
 {% tab title="Vanilla API" %}
@@ -53,7 +53,7 @@ export const {
 {% endtab %}
 {% endtabs %}
 
-### Displaying a coutdown timer before auto logout
+### Displaying a countdown timer before auto logout
 
 {% embed url="https://youtu.be/GeZaZIr-d68" %}
 The demo app with a short SSO Session Idle
@@ -79,11 +79,11 @@ const { unsubscribeFromAutoLogoutCountdown } = oidc.subscribeToAutoLogoutCountdo
 
 {% tab title="React API" %}
 {% embed url="https://github.com/keycloakify/oidc-spa/blob/main/examples/tanstack-router/src/router/AutoLogoutCountdown.tsx" %}
-Example implementation of a 60 seconds countdown before autologout.
+Example implementation of a 60 seconds countdown before auto logout.
 {% endembed %}
 {% endtab %}
 {% endtabs %}
 
-[^1]: If you're not sure use createOidc({ debugLogs: true }) ans see what's printed in the console after you  log in.\
+[^1]: If you're not sure use `createOidc({ debugLogs: true })` and see what's printed in the console after you log in.\
     \
-    For reference, if you are using Keycloak you do not need to provide the `idleSessionLifetimeInSeconds` parameter to oidc-spa, with Auth0, you do.&#x20;
+    For reference, if you are using Keycloak, you do not need to provide the `idleSessionLifetimeInSeconds` parameter to oidc-spa, with Auth0, you do.


### PR DESCRIPTION
This fixes some typos in the auto logout documentation.